### PR TITLE
Fix GitHub Actions workflow syntax error

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -26,7 +26,7 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           
     - name: Setup Cachix
-      if: ${{ secrets.CACHIX_AUTH_TOKEN != '' }}
+      if: ${{ secrets.CACHIX_AUTH_TOKEN }}
       uses: cachix/cachix-action@v13
       with:
         name: nix-community


### PR DESCRIPTION
## Summary
- Fix secrets context usage in ci-simple.yml workflow
- Resolve validation error preventing proper workflow execution

## Changes
- **Line 29**: Changed `if: ${{ secrets.CACHIX_AUTH_TOKEN \!= '' }}` to `if: ${{ secrets.CACHIX_AUTH_TOKEN }}`
- This fixes the "Unrecognized named-value: 'secrets'" error in GitHub Actions

## Test plan
- [ ] Verify workflow passes GitHub Actions validation
- [ ] Confirm CI runs successfully on push/PR

🤖 Generated with [Claude Code](https://claude.ai/code)