### PR TITLE
Fix GitHub Actions workflow secret check syntax error

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -26,11 +26,13 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           
     - name: Setup Cachix
-      if: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      if: env.CACHIX_AUTH_TOKEN
       uses: cachix/cachix-action@v13
+      env:
+        CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       with:
         name: nix-community
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        authToken: '${{ env.CACHIX_AUTH_TOKEN }}'
         skipPush: true
         
     - name: Check flake syntax


### PR DESCRIPTION
- Change from direct secrets usage in if condition to environment variable approach
- Use 'if: env.CACHIX_AUTH_TOKEN' instead of 'if: ${{ secrets.CACHIX_AUTH_TOKEN }}'
- Map secret to environment variable in step and reference env var in authToken
- This resolves the "Unrecognized named-value: 'secrets'" validation error

🤖 Generated with [Claude Code](https://claude.ai/code)