### PR TITLE
Fix CI workflow badge link in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
       <br>
    </div>
    <div>
-      <a href="https://github.com/MoshPitCodes/moshpitcodes.nix/actions/workflows/ci.yml">
-         <img src="https://img.shields.io/github/actions/workflow/status/MoshPitCodes/moshpitcodes.nix/ci.yml?branch=main&style=for-the-badge&labelColor=282828&logo=github&logoColor=D79921&color=D79921&label=CI">
+      <a href="https://github.com/MoshPitCodes/moshpitcodes.nix/actions/workflows/ci-simple.yml">
+         <img src="https://img.shields.io/github/actions/workflow/status/MoshPitCodes/moshpitcodes.nix/ci-simple.yml?branch=main&style=for-the-badge&labelColor=282828&logo=github&logoColor=D79921&color=D79921&label=CI">
       </a>
       <a href="https://github.com/MoshPitCodes/moshpitcodes.nix/actions/workflows/format.yml">
          <img src="https://img.shields.io/github/actions/workflow/status/MoshPitCodes/moshpitcodes.nix/format.yml?branch=main&style=for-the-badge&labelColor=282828&logo=github&logoColor=FB4934&color=FB4934&label=Format">


### PR DESCRIPTION
## Summary
- Update CI workflow badge link from `ci.yml` to `ci-simple.yml` in README header
- Ensures CI badge displays correct workflow status

## Changes
- **README.md line 27**: Changed workflow link from `ci.yml` to `ci-simple.yml`
- This matches the current active workflow file structure after recent reorganization

## Test plan
- [ ] Verify CI badge displays correctly on GitHub
- [ ] Confirm link navigates to correct workflow

🤖 Generated with [Claude Code](https://claude.ai/code)