### PR TITLE
Fix GitHub Actions workflow secret conditional syntax

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -26,7 +26,7 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           
     - name: Setup Cachix
-      if: ${{ secrets.CACHIX_AUTH_TOKEN != '' }}
+      if: secrets.CACHIX_AUTH_TOKEN != ''
       uses: cachix/cachix-action@v13
       with:
         name: nix-community


### PR DESCRIPTION
## Summary
• Fixed invalid workflow syntax error in ci-simple.yml
• Removed unnecessary `${{ }}` wrapper in conditional expression

## Problem
GitHub Actions was reporting an error:
```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.CACHIX_AUTH_TOKEN \!= ''
```

## Solution
Changed from:
```yaml
if: ${{ secrets.CACHIX_AUTH_TOKEN \!= '' }}
```

To:
```yaml
if: secrets.CACHIX_AUTH_TOKEN \!= ''
```

The `${{ }}` syntax is not needed for the `if` conditional at the job/step level.

## Test plan
- [ ] Verify workflow runs without syntax errors
- [ ] Confirm CI badge shows passing status

🤖 Generated with [Claude Code](https://claude.ai/code)