### PR TITLE
Fix GitHub Actions workflow secret conditional syntax

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -26,7 +26,9 @@ jobs:
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           
     - name: Setup Cachix
-      if: secrets.CACHIX_AUTH_TOKEN != ''
+      env:
+        CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      if: env.CACHIX_AUTH_TOKEN != ''
       uses: cachix/cachix-action@v13
       with:
         name: nix-community


### PR DESCRIPTION
## Summary
• Fixed the invalid workflow syntax error in `ci-simple.yml` 
• Changed from unsupported `if: secrets.CACHIX_AUTH_TOKEN \!= ''` to proper `if: env.CACHIX_AUTH_TOKEN \!= ''`
• Added environment variable block to expose secret for conditional checking

## Problem
GitHub Actions was reporting a syntax error:
```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.CACHIX_AUTH_TOKEN \!= ''
```

This happens because the `secrets` context cannot be directly referenced in `if` conditionals for security reasons.

## Solution
The correct approach is to:
1. Expose the secret as an environment variable using `env:`
2. Reference the environment variable in the conditional using `env.CACHIX_AUTH_TOKEN`

**Before:**
```yaml
- name: Setup Cachix
  if: secrets.CACHIX_AUTH_TOKEN \!= ''
  uses: cachix/cachix-action@v13
```

**After:**
```yaml
- name: Setup Cachix
  env:
    CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
  if: env.CACHIX_AUTH_TOKEN \!= ''
  uses: cachix/cachix-action@v13
```

## Test plan
- [x] Workflow syntax validates without errors
- [ ] CI badge displays correct status after merge
- [ ] Workflow runs successfully (with or without CACHIX_AUTH_TOKEN secret)

🤖 Generated with [Claude Code](https://claude.ai/code)