### PR TITLE
Fix CI secrets import by using secrets.nix.example fallback

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,9 @@
         inherit system;
         config.allowUnfree = true;
       };
-      customsecrets = import ./secrets.nix;
+      customsecrets = if builtins.pathExists ./secrets.nix 
+        then import ./secrets.nix 
+        else import ./secrets.nix.example;
       username = customsecrets.username;
 
     in

--- a/secrets.nix.example
+++ b/secrets.nix.example
@@ -4,24 +4,26 @@
 
 {
   # User configuration
-  username = "your-username-here";
+  username = "testuser";
+  reponame = "moshpitcodes.nix";
 
   # Git configuration
   git = {
-    userName = "your-git-username";
-    userEmail = "your-email@example.com";
+    userName = "Test User";
+    userEmail = "test@example.com";
+    user.signingkey = "testkey";
   };
 
   # Network configuration
   network = {
-    wifiSSID = "your-wifi-network-name";
-    wifiPassword = "your-wifi-password";
+    wifiSSID = "";
+    wifiPassword = "";
   };
 
   # API keys for development tools
   apiKeys = {
-    anthropic = "your-claude-api-key";
-    openai = "your-openai-api-key";
+    anthropic = "";
+    openai = "";
   };
 
   # Alternative approach using environment variables


### PR DESCRIPTION
## Summary
• Fixed CI failure caused by missing secrets.nix file
• Updated flake.nix to use secrets.nix.example as fallback when secrets.nix doesn't exist
• Updated secrets.nix.example with CI-safe test values instead of placeholder strings

## Problem
The CI was failing because flake.nix was trying to import `./secrets.nix` directly, but this file doesn't exist in the repository (correctly for security reasons). This caused the error:
```
error: getting status of '/nix/store/.../secrets.nix': No such file or directory
```

## Solution
1. **Conditional Import**: Updated flake.nix to check if secrets.nix exists before importing
2. **Use Example File**: When secrets.nix doesn't exist, fall back to importing secrets.nix.example
3. **CI-Safe Values**: Updated secrets.nix.example with actual test values instead of placeholder text

**Before:**
```nix
customsecrets = import ./secrets.nix;
```

**After:**
```nix
customsecrets = if builtins.pathExists ./secrets.nix 
  then import ./secrets.nix 
  else import ./secrets.nix.example;
```

## Benefits
- ✅ CI can now build without requiring actual secrets
- ✅ Maintains security by keeping real secrets out of the repository
- ✅ Uses existing infrastructure (secrets.nix.example) instead of hardcoding values
- ✅ Clean separation between example and actual secrets

## Test plan
- [x] Push to branch triggers CI workflows
- [ ] All three workflows (test-flake, test-home-manager, test-systems) should pass
- [ ] Verify flake check passes without secrets.nix file
- [ ] Confirm local development still works with actual secrets.nix

🤖 Generated with [Claude Code](https://claude.ai/code)