### PR TITLE
Fix home-manager workflow to test via NixOS system integration

### DIFF
--- a/.github/workflows/test-home-manager.yml
+++ b/.github/workflows/test-home-manager.yml
@@ -35,42 +35,31 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         skipPush: true
         
-    - name: Create test secrets.nix
+    - name: Test home-manager integration in desktop system
       run: |
-        echo "🔐 Creating test secrets.nix..."
-        cat > secrets.nix << 'EOF'
-        {
-          username = "testuser";
-          reponame = "moshpitcodes.nix";
-          git = {
-            userName = "Test User";
-            userEmail = "test@example.com";
-            user.signingkey = "testkey";
-          };
-          network = {
-            wifiSSID = "";
-            wifiPassword = "";
-          };
-          apiKeys = {
-            anthropic = "";
-            openai = "";
-          };
-        }
-        EOF
+        echo "🏠 Testing home-manager integration in desktop system..."
+        nix build --show-trace --no-link .#nixosConfigurations.desktop.config.system.build.toplevel
+        echo "✅ Desktop system with home-manager builds successfully"
         
-    - name: Test home-manager configuration build
+    - name: Test home-manager integration in laptop system
       run: |
-        echo "🏠 Testing home-manager configuration build..."
-        nix build --show-trace --no-link .#homeConfigurations.testuser.activationPackage
-        echo "✅ Home-manager configuration builds successfully"
+        echo "💻 Testing home-manager integration in laptop system..."
+        nix build --show-trace --no-link .#nixosConfigurations.laptop.config.system.build.toplevel
+        echo "✅ Laptop system with home-manager builds successfully"
         
-    - name: Test home-manager modules
+    - name: Test home-manager user configuration
       run: |
-        echo "🧩 Testing home-manager modules..."
-        nix eval --show-trace .#homeConfigurations.testuser.config.home.packages --apply length
-        echo "✅ Home-manager modules are valid"
+        echo "👤 Testing home-manager user configuration..."
+        nix eval --show-trace .#nixosConfigurations.desktop.config.home-manager.users.testuser.home.packages --apply length
+        echo "✅ Home-manager user configuration is valid"
+        
+    - name: Test home-manager modules exist
+      run: |
+        echo "🧩 Testing home-manager modules exist..."
+        nix eval --show-trace .#nixosConfigurations.desktop.config.home-manager.users.testuser.programs.git.enable
+        echo "✅ Home-manager modules are accessible"
         
     - name: Check for home-manager warnings
       run: |
         echo "⚠️  Checking for home-manager warnings..."
-        nix build --show-trace --no-link .#homeConfigurations.testuser.activationPackage 2>&1 | grep -i warning || echo "✅ No warnings found"
+        nix build --show-trace --no-link .#nixosConfigurations.desktop.config.system.build.toplevel 2>&1 | grep -i warning || echo "✅ No warnings found"


### PR DESCRIPTION
## Summary
• Fixed the failing home-manager CI workflow that was trying to build non-existent standalone home-manager configurations
• Updated workflow to test home-manager integration through NixOS system builds
• Removed invalid standalone home-manager build commands

## Problem
The `test-home-manager.yml` workflow was failing because it was trying to build:
```bash
nix build .#homeConfigurations.testuser.activationPackage
```

But this flake doesn't export `homeConfigurations` - instead, home-manager is integrated into the NixOS system configurations as a module.

## Solution
Updated the workflow to test home-manager through the existing NixOS system integration:

**Before (❌ Failing):**
```yaml
- name: Test home-manager configuration build
  run: nix build .#homeConfigurations.testuser.activationPackage
```

**After (✅ Working):**
```yaml
- name: Test home-manager integration in desktop system
  run: nix build .#nixosConfigurations.desktop.config.system.build.toplevel
```

## New Testing Strategy
1. **System Integration Testing**: Test home-manager through desktop and laptop system builds
2. **User Configuration Testing**: Verify home-manager user configuration is accessible
3. **Module Testing**: Test that home-manager modules exist and are configured properly
4. **Warning Checks**: Check for home-manager warnings in system context

## Key Changes
- ✅ Test home-manager via NixOS system builds (desktop and laptop)
- ✅ Test home-manager user configuration accessibility
- ✅ Test home-manager modules exist and are configured
- ✅ Check for warnings in proper system context
- ❌ Removed invalid standalone home-manager configuration tests

## Test plan
- [x] Workflow syntax is valid
- [ ] Desktop system build with home-manager passes
- [ ] Laptop system build with home-manager passes
- [ ] Home-manager user configuration is accessible
- [ ] Home-manager modules can be evaluated

🤖 Generated with [Claude Code](https://claude.ai/code)