### PR TITLE
Fix zen-browser hash mismatch causing test-flake workflow failure

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1225,11 +1225,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1751858709,
-        "narHash": "sha256-xghd1GDPRSa6aD6tEk2JCuQDZWdHITlCA/stwSVoZJQ=",
+        "lastModified": 1751930356,
+        "narHash": "sha256-xiG5vY4KhrIfUGb/MyPXaDiatFJ0mQngook01X4VwHg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "216dd333fa41aa013bf8aab9322d7c1a2aee5b4a",
+        "rev": "06c1a125bfa2002e9d84ebf655271c6f06ab1f38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
• Fixed the failing "test flake" workflow by updating zen-browser flake input
• Resolved hash mismatch error that was preventing CI from passing

## Problem
The "test flake" workflow was failing with this error:
```
error: hash mismatch in file downloaded from 'https://github.com/zen-browser/desktop/releases/download/twilight/zen.linux-x86_64.tar.xz':
  specified: sha256:1b7ciyzm3y3vqlm68ndm5941jr276ai3v6s27q5c62x0xrh3qhd0
  got:       sha256:16fkh6wmy06k49icwxn72knsf42cwwbvpajbrrq8b4b8ishx3m4h
```

## Solution
Updated zen-browser flake input to the latest version:
- Updated from rev `216dd33` to `06c1a12` 
- This synchronizes the expected hash with the actual file hash
- Verified `nix flake check` passes locally after the update

## Changes
- Updated `flake.lock` with correct zen-browser hash
- No functional changes to the actual configuration
- Fixes CI workflow failures across all three workflows (test-flake, test-home-manager, test-systems)

## Test plan
- [x] `nix flake check` passes locally
- [ ] "test flake" workflow passes in CI
- [ ] All three CI workflows should now pass

This is a common maintenance task when external flake inputs update their packages.

🤖 Generated with [Claude Code](https://claude.ai/code)