### PR TITLE
Fix home-manager CI workflow secrets import

### DIFF
--- a/.github/workflows/test-home-manager.yml
+++ b/.github/workflows/test-home-manager.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Test home-manager user configuration
       run: |
         echo "👤 Testing home-manager user configuration..."
-        nix eval --show-trace .#nixosConfigurations.desktop.config.home-manager.users.testuser.home.packages --apply length
+        nix eval --show-trace .#nixosConfigurations.desktop.config.home-manager.users.testuser.home.packages --apply "builtins.length"
         echo "✅ Home-manager user configuration is valid"
         
     - name: Test home-manager modules exist

--- a/flake.nix
+++ b/flake.nix
@@ -41,9 +41,13 @@
         inherit system;
         config.allowUnfree = true;
       };
-      customsecrets = if builtins.pathExists ./secrets.nix 
-        then import ./secrets.nix 
-        else import ./secrets.nix.example;
+      customsecrets = 
+        let 
+          fallbackPath = ./secrets.nix.example;
+          # Check if secrets.nix exists in the source tree
+          hasSecrets = builtins.pathExists (self + "/secrets.nix");
+        in
+        if hasSecrets then import (self + "/secrets.nix") else import fallbackPath;
       username = customsecrets.username;
 
     in


### PR DESCRIPTION
## Summary
- Fixed CI failure in test-home-manager workflow caused by secrets.nix path resolution issues
- Replaced relative path `./secrets.nix` with `self + "/secrets.nix"` for proper flake context resolution
- Ensured fallback to `secrets.nix.example` works correctly in CI environment

## Root Cause
The `builtins.pathExists ./secrets.nix` check was failing in CI because when flakes are evaluated, they get copied to the Nix store where relative paths don't resolve the same way as in the source directory.

## Test Plan
- [x] Verify `nix eval .#nixosConfigurations.desktop.config.system.build.toplevel.drvPath` works locally
- [x] Verify `nix eval .#nixosConfigurations.laptop.config.system.build.toplevel.drvPath` works locally  
- [x] Verify home-manager user configuration access works
- [x] Verify home-manager modules are accessible
- [ ] Confirm CI workflow passes after merge

🤖 Generated with [Claude Code](https://claude.ai/code)