### PR TITLE
Fix CI workflows and syntax errors

### DIFF
--- a/.github/workflows/test-flake.yml
+++ b/.github/workflows/test-flake.yml
@@ -35,6 +35,12 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         skipPush: true
         
+    - name: Create secrets.nix for CI
+      run: |
+        echo "📝 Creating secrets.nix for CI environment..."
+        cp secrets.nix.example secrets.nix
+        echo "✅ Secrets file created"
+        
     - name: Check flake syntax
       run: |
         echo "🔍 Checking flake syntax..."

--- a/.github/workflows/test-home-manager.yml
+++ b/.github/workflows/test-home-manager.yml
@@ -46,6 +46,12 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         skipPush: true
         
+    - name: Create secrets.nix for CI
+      run: |
+        echo "📝 Creating secrets.nix for CI environment..."
+        cp secrets.nix.example secrets.nix
+        echo "✅ Secrets file created"
+        
     - name: Test home-manager configuration validity in desktop
       run: |
         echo "🏠 Testing home-manager configuration validity in desktop..."

--- a/.github/workflows/test-systems.yml
+++ b/.github/workflows/test-systems.yml
@@ -50,6 +50,12 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         skipPush: true
         
+    - name: Create secrets.nix for CI
+      run: |
+        echo "📝 Creating secrets.nix for CI environment..."
+        cp secrets.nix.example secrets.nix
+        echo "✅ Secrets file created"
+        
     - name: Test ${{ matrix.host }} system configuration validity
       run: |
         echo "✅ Testing ${{ matrix.host }} system configuration validity..."

--- a/modules/core/user.nix
+++ b/modules/core/user.nix
@@ -34,4 +34,4 @@
     shell = pkgs.zsh;
   };
   nix.settings.allowed-users = [ "${username}" ];
-# }
+}

--- a/secrets.nix.example
+++ b/secrets.nix.example
@@ -5,6 +5,7 @@
 {
   # User configuration
   username = "testuser";
+  password = "testpassword"; # Use a strong password
   reponame = "moshpitcodes.nix";
 
   # Git configuration


### PR DESCRIPTION
## Summary
- Fix critical syntax error in `modules/core/user.nix` (missing closing brace causing flake check failures)
- Add `secrets.nix` creation step to all CI workflows to prevent "Secrets file not found" errors
- Update `secrets.nix.example` to include missing `password` field required by user module
- Ensure all CI workflows (test-flake, test-systems, test-home-manager) can run successfully

## Root Cause
The CI workflows were failing because:
1. `modules/core/user.nix` had a syntax error (commented closing brace instead of actual closing brace)
2. CI workflows couldn't find `secrets.nix` file (git-ignored) causing flake evaluation failures
3. `secrets.nix.example` was missing the `password` field that the user module expects

## Test plan
- [ ] Verify `nix flake check` passes locally with example secrets
- [ ] Confirm all CI workflows pass on this branch
- [ ] Check that flake syntax validation succeeds
- [ ] Validate system configurations build without errors

🤖 Generated with [Claude Code](https://claude.ai/code)