### PR TITLE
chore: add static /etc/hosts entries for arcane.home.arpa

### DIFF
--- a/modules/core/network.nix
+++ b/modules/core/network.nix
@@ -11,6 +11,15 @@
       allowedUDPPorts = [ ];
     };
 
+    # Static /etc/hosts entries
+    hosts = {
+      "192.168.178.50" = [
+        "arcane.home.arpa"
+        "grafana.home.arpa"
+        "prometheus.home.arpa"
+      ];
+    };
+
     # DNS servers
     nameservers = [
       "8.8.8.8"


### PR DESCRIPTION
## Summary

- Adds `networking.hosts` entries in `modules/core/network.nix` mapping `192.168.178.50` to `arcane.home.arpa`, `grafana.home.arpa`, and `prometheus.home.arpa`
- Ensures all hosts resolve these names locally without relying on DNS

## Impact

- Affects all hosts that import `modules/core/network.nix`
- No breaking changes

## Files Changed

- `modules/core/network.nix` — added `networking.hosts` block

## Testing Performed

- Verified change renders correctly via `git diff`
- Apply with `sudo nixos-rebuild switch --flake . --impure` and confirm entries appear in `/etc/hosts`