### PR TITLE
chore: add more home.arpa service aliases

### DIFF
--- a/modules/core/network.nix
+++ b/modules/core/network.nix
@@ -19,8 +19,12 @@
         "caddy.home.arpa"
         "grafana.home.arpa"
         "homepage.home.arpa"
+        "homeassistant.home.arpa"
+        "jellyfin.home.arpa"
+        "metube.home.arpa"
         "pgadmin.home.arpa"
         "prometheus.home.arpa"
+        "wallos.home.arpa"
       ];
     };
 

--- a/modules/core/network.nix
+++ b/modules/core/network.nix
@@ -22,6 +22,7 @@
         "homeassistant.home.arpa"
         "jellyfin.home.arpa"
         "metube.home.arpa"
+        "n8n.home.arpa"
         "pgadmin.home.arpa"
         "prometheus.home.arpa"
         "wallos.home.arpa"


### PR DESCRIPTION
## Why this change exists
Static local DNS aliases should cover the current self-hosted services exposed behind `192.168.178.50`.

## What changed
- added `homeassistant.home.arpa`, `jellyfin.home.arpa`, `metube.home.arpa`, `n8n.home.arpa`, and `wallos.home.arpa` to the shared static hosts mapping
- kept the change isolated to `modules/core/network.nix`

## Validation performed
- Ran `nix eval .#nixosConfigurations.desktop.config.networking.hosts --json --impure`
- Confirmed the evaluated hosts mapping includes all expected `*.home.arpa` aliases for `192.168.178.50`

## Risks and rollback plan
- Low risk: only updates static host aliases
- Roll back by removing the added aliases from `modules/core/network.nix`

## Summary
- Expands the shared `home.arpa` host aliases for services on `192.168.178.50`
- Improves local hostname resolution consistency for self-hosted apps

## Impact
- Affects local hostname resolution only
- No secrets changes required
- No breaking changes expected

## Files changed
- `modules/core/network.nix` - added five service aliases to the static hosts mapping

## Testing performed
- `nix eval .#nixosConfigurations.desktop.config.networking.hosts --json --impure`

## Issues closed
- Refs `td-0e5ac2`